### PR TITLE
remove lto to fix link error of clang

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,6 @@ add_project_arguments(['-D_GNU_SOURCE=1',
                        '-D_TIME_BITS=64'], language : 'c')
 
 possible_cc_flags = [
-                  '-flto=auto',
                   '-ffat-lto-objects',
 		  '-fstack-protector-strong',
 		  '-funwind-tables',


### PR DESCRIPTION
When build wtmpdb with clang, the following error occurs:

| tests/tst-dlopen.p/tst-dlopen.c.o: file not recognized: file format not recognized
| clang-16: error: linker command failed with exit code 1 (use -v to see invocation)