### PR TITLE
last: Add support for time-format option

### DIFF
--- a/man/wtmpdb.8.xml
+++ b/man/wtmpdb.8.xml
@@ -192,6 +192,27 @@
 		</para>
 	      </listitem>
 	    </varlistentry>
+	    <varlistentry>
+	      <term>
+		<option>--time-format</option>
+		<replaceable>FORMAT</replaceable>
+	      </term>
+	      <listitem>
+		<para>
+		  Display timestamps in the specified
+		  <replaceable>FORMAT</replaceable>. The format can be
+		  <replaceable>notime</replaceable>,
+		  <replaceable>short</replaceable>,
+		  <replaceable>full</replaceable>, or
+		  <replaceable>iso</replaceable>.
+		  <replaceable>notime</replaceable> will not display times at
+		  all, <replaceable>short</replaceable> is the default option,
+		  <replaceable>full</replaceable> will display the full times
+		  and dates, and <replaceable>iso</replaceable> will display
+		  times in ISO-8601 format.
+		</para>
+	      </listitem>
+	    </varlistentry>
 	  </variablelist>
 	  <para>
 	    <replaceable>TIME</replaceable> must be in the format

--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -161,13 +161,37 @@ static int
 time_format (const char *fmt)
 {
   if (strcmp (fmt, "notime") == 0)
-    return TIMEFMT_NOTIME;
+    {
+      login_fmt = TIMEFMT_NOTIME;
+      login_len = 0;
+      logout_fmt = TIMEFMT_NOTIME;
+      logout_len = 0;
+      return TIMEFMT_NOTIME;
+    }
   if (strcmp (fmt, "short") == 0)
-    return TIMEFMT_SHORT;
+    {
+      login_fmt = TIMEFMT_SHORT;
+      login_len = 16;
+      logout_fmt = TIMEFMT_HHMM;
+      logout_len = 5;
+      return TIMEFMT_SHORT;
+    }
   if (strcmp (fmt, "full") == 0)
-    return TIMEFMT_CTIME;
+   {
+     login_fmt = TIMEFMT_CTIME;
+     login_len = 24;
+     logout_fmt = TIMEFMT_CTIME;
+     logout_len = 24;
+     return TIMEFMT_CTIME;
+   }
   if (strcmp (fmt, "iso") == 0)
-    return TIMEFMT_ISO;
+   {
+     login_fmt = TIMEFMT_ISO;
+     login_len = 25;
+     logout_fmt = TIMEFMT_ISO;
+     logout_len = 25;
+     return TIMEFMT_ISO;
+   }
 
   return -1;
 }

--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -541,6 +541,9 @@ usage (int retval)
   fputs ("  -t, --until TIME    Display who was logged in until TIME\n", output);
   fputs ("  -w, --fullnames     Display full IP addresses and user and domain names\n", output);
   fputs ("  -x, --system        Display system shutdown entries\n", output);
+  fputs ("      --time-format FORMAT  Display timestamps in the specified FORMAT:\n", output);
+  fputs ("                              notime|short|full|iso\n", output);
+
   fputs ("  [username...]       Display only entries matching these arguments\n", output);
   fputs ("  [tty...]            Display only entries matching these arguments\n", output);
   fputs ("TIME must be in the format \"YYYY-MM-DD HH:MM:SS\"\n", output);


### PR DESCRIPTION
[Cockpit](https://github.com/cockpit-project/cockpit/blob/main/pkg/users/account-logs-panel.jsx#L34) requires the time-format option in `last` to work properly.

This PR adds support for the time-format option and tries to mimic the original formats as closely as possible.

Related bugzilla about the issue in Cockpit: https://bugzilla.suse.com/show_bug.cgi?id=1218157