### PR TITLE
include libgen.h for basename

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -30,6 +30,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <errno.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
basename prototype has been removed from string.h from latest musl [1] compilers e.g. clang-18 flags the absense of prototype as error. therefore include libgen.h for providing it.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7