### PR TITLE
zero struct tm before calling strptime()

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -133,7 +133,7 @@ isipaddr (const char *string, int *addr_type,
 static int
 parse_time (const char *str, time_t *arg)
 {
-  struct tm res;
+  struct tm res = { 0 };
 
   if (strcmp (str, "today") == 0)
     {


### PR DESCRIPTION
This fixes erratic behaviour with options like `--until` which can cut off the display at different places. Typically this might be +/- one hour. This happens because `strptime()` only sets fields corresponding to time elements present in the format string.

Without this fix I see the time value that `until` gets, vary by 3600.

Thanks!