### PR TITLE
Fix flaky tst-login-logout (rotation) test

### DIFF
--- a/lib/sqlite.c
+++ b/lib/sqlite.c
@@ -526,11 +526,11 @@ sqlite_rotate(const char *db_path, const int days, char **wtmpdb_name,
   sqlite3 *db_src;
   sqlite3 *db_dest;
   uint64_t counter = 0;
-  struct timespec ts_now;
-  clock_gettime (CLOCK_REALTIME, &ts_now);
-  time_t offset = ts_now.tv_sec - days * 86400;
-  struct tm *tm = localtime (&offset);
-  uint64_t login_t = offset * USEC_PER_SEC;
+  struct timespec threshold;
+  clock_gettime (CLOCK_REALTIME, &threshold);
+  threshold.tv_sec -= days * 86400;
+  struct tm *tm = localtime (&threshold.tv_sec);
+  uint64_t login_t = wtmpdb_timespec2usec (threshold);
   char date[10];
   strftime (date, 10, "%Y%m%d", tm);
   char *dest_path = NULL;

--- a/tests/tst-login-logout.c
+++ b/tests/tst-login-logout.c
@@ -184,17 +184,6 @@ main(void)
   /* make sure there is no old stuff flying around. The backup file is not so important. */
   remove (db_path);
 
-  if (test_args (db_path, "user1", "test-tty", "localhost", NULL, 4) != 0)
-    return 1;
-  if (test_args (db_path, "user2", NULL, NULL, NULL, 4) != 0)
-    return 1;
-  if (test_args (db_path, "user3", NULL, NULL, NULL, 4) != 0)
-    return 1;
-  if (test_args (db_path, "user4", "test-tty", NULL, NULL, 4) != 0)
-    return 1;
-  if (test_args (db_path, "user5", NULL, "localhost", NULL, 4) != 0)
-    return 1;
-
   if (test_args (db_path, "user1", "test-tty", "localhost", NULL, 3) != 0)
     return 1;
   if (test_args (db_path, "user2", NULL, NULL, NULL, 3) != 0)
@@ -204,6 +193,17 @@ main(void)
   if (test_args (db_path, "user4", "test-tty", NULL, NULL, 3) != 0)
     return 1;
   if (test_args (db_path, "user5", NULL, "localhost", NULL, 3) != 0)
+    return 1;
+
+  if (test_args (db_path, "user1", "test-tty", "localhost", NULL, 2) != 0)
+    return 1;
+  if (test_args (db_path, "user2", NULL, NULL, NULL, 2) != 0)
+    return 1;
+  if (test_args (db_path, "user3", NULL, NULL, NULL, 2) != 0)
+    return 1;
+  if (test_args (db_path, "user4", "test-tty", NULL, NULL, 2) != 0)
+    return 1;
+  if (test_args (db_path, "user5", NULL, "localhost", NULL, 2) != 0)
     return 1;
 
   if (test_rotate (db_path, 3) != 0)


### PR DESCRIPTION
I think I've fixed the flaky `tst-login-logout` test which would fail on some proportion of runs if you run the tests on a loop:

```
4/4 tst-login-logout              FAIL            0.11s   exit status 1
>>> UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MALLOC_PERTURB_=95 MESON_TEST_ITERATION=1 LD_LIBRARY_PATH=/ubuntu/home/andy/git/wtmpdb/build/ MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 /ubuntu/home/andy/git/wtmpdb/build/tests/tst-login-logout
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
stderr:
wtmpdb_read_all returned 3 expected 5
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――


Summary of Failures:

4/4 tst-login-logout       FAIL            0.11s   exit status 1
```

The commit logs cover my findings:

**rotate: don't throw away microseconds calculating threshold**

> Throwing away the microseconds from the rotation threshold doesn't affect real world usage but it does make tests unreliable because it means the outcome is sensitive to exactly which part of a second the test is running in and if near the rollover point then a different result is obtained.

**test: schedule test logins on correct day**

> As the current time is moving on throught the test, the calculation of "n days ago" ends up picking a time which is slightly more than "n days ago", so reduce n by one. This error was mostly neutralised by the rotation threshold throwing away microseconds, but with that fixed, the tests always fail unless this is also fixed.
