### PR TITLE
Add legacy wtmp log importer

### DIFF
--- a/man/wtmpdb.8.xml
+++ b/man/wtmpdb.8.xml
@@ -314,6 +314,30 @@
 	</listitem>
       </varlistentry>
       <varlistentry>
+        <term><command>import</command>
+	  <optional><replaceable>option</replaceable>…</optional>
+	  <replaceable>file</replaceable>…
+	</term>
+	<listitem>
+          <para>
+	    <command>wtmpdb import</command> imports legacy wtmp log
+	    files to the <filename>/var/lib/wtmpdb/wtmp.db</filename>
+	    database.
+	  </para>
+	  <title>import options</title>
+	  <varlistentry>
+	    <term>
+	      <option>-f, --file</option> <replaceable>FILE</replaceable>
+	    </term>
+	    <listitem>
+	      <para>
+		Use <replaceable>FILE</replaceable> as wtmpdb database.
+	      </para>
+	    </listitem>
+	  </varlistentry>
+	</listitem>
+      </varlistentry>
+      <varlistentry>
 	<term>global options</term>
 	<title>global options</title>
 	<varlistentry>

--- a/meson.build
+++ b/meson.build
@@ -151,7 +151,7 @@ pam_wtmpdb = shared_library(
   install_dir : pamlibdir
 )
 
-wtmpdb_c = ['src/wtmpdb.c']
+wtmpdb_c = ['src/wtmpdb.c', 'src/import.c']
 wtmpdbd_c = ['src/wtmpdbd.c', 'src/varlink-org.openSUSE.wtmpdb.c', 'lib/mkdir_p.c']
 
 if have_systemd257

--- a/src/import.c
+++ b/src/import.c
@@ -1,0 +1,192 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+
+  Copyright (c) 2025, Andrew Bower <andrew@bower.uk>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <limits.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <utmp.h>
+
+enum utmp_type {
+  UTMP_EMPTY = EMPTY,
+  UTMP_RUN_LVL = RUN_LVL,
+  UTMP_BOOT_TIME = BOOT_TIME,
+  UTMP_USER_PROCESS = USER_PROCESS,
+  UTMP_DEAD_PROCESS = DEAD_PROCESS,
+};
+
+#undef EMPTY
+#undef RUN_LVL
+#undef BOOT_TIME
+#undef USER_PROCESS
+
+#include "wtmpdb.h"
+#include "import.h"
+
+/* Import utmp entries from memory into a wtmpdb-format database.
+   Returns 0 on success, -1 on failure. */
+static int
+import_utmp_records (const char *db_path,
+		     const struct utmp *utmp_data,
+		     int entries,
+		     char **error)
+{
+  int64_t last_reboot_id = -1;
+  int64_t *id_map;
+  int row = 0;
+  int ret = 0;
+
+  id_map = calloc (entries, sizeof *id_map);
+  if (id_map == NULL)
+    {
+      *error = strdup ("wtmpdb_import: out of memory allocating id map");
+      return -1;
+    }
+
+  for (row = 0; ret == 0 && row < entries; row++)
+    {
+      const struct utmp *u = utmp_data + row;
+      const struct utmp *v;
+      int64_t id = -1;
+      int64_t usecs = USEC_PER_SEC * u->ut_tv.tv_sec + u->ut_tv.tv_usec;
+
+      switch (u->ut_type)
+	{
+	case UTMP_RUN_LVL:
+	case UTMP_BOOT_TIME:
+	  if (u->ut_id[0] == '~' &&
+	      u->ut_id[1] == '~' &&
+	      u->ut_id[2] == '\0')
+	    {
+	      if (strcmp (u->ut_user, "reboot") == 0)
+		{
+		  id = wtmpdb_login (db_path, BOOT_TIME, "reboot", usecs, "~",
+				     u->ut_host, NULL, error);
+		  ret = id == -1 ? -1 : 0;
+		  last_reboot_id = id;
+		}
+	      else if (strcmp (u->ut_user, "shutdown") == 0 &&
+		       last_reboot_id != -1)
+		{
+		  ret = wtmpdb_logout (db_path, last_reboot_id, usecs, error);
+		  last_reboot_id = -1;
+		}
+	    }
+	  break;
+	case UTMP_USER_PROCESS:
+	  id = wtmpdb_login (db_path, USER_PROCESS, u->ut_user, usecs,
+			     u->ut_line, u->ut_host, NULL, error);
+	  ret = id == -1 ? -1 : 0;
+	  break;
+	case UTMP_DEAD_PROCESS:
+	  for (v = u - 1; v >= utmp_data && v->ut_type != UTMP_BOOT_TIME; v--)
+	    {
+	      if (v->ut_type == UTMP_USER_PROCESS &&
+		  ((u->ut_pid != 0 && v->ut_pid == u->ut_pid) ||
+		   (u->ut_pid == 0 && strncmp (v->ut_line, u->ut_line, UT_LINESIZE) == 0)))
+		{
+		  id = id_map[v - utmp_data];
+		  if (id > 0)
+		    ret = wtmpdb_logout (db_path, id, usecs, error);
+		  break;
+		}
+	    }
+	  break;
+	}
+
+      id_map[row] = id;
+    }
+
+  free (id_map);
+
+  return ret;
+}
+
+/* Import a wtmp log file into a wtmpdb-format database.
+   Returns 0 on success, -1 on failure. */
+int
+import_wtmp_file (const char *db_path,
+		  const char *file)
+{
+  struct stat statbuf;
+  char *error = NULL;
+  int64_t entries;
+  void *data;
+  int fd;
+  int rc;
+
+  fd = open (file, O_RDONLY);
+  if (fd == -1)
+    {
+      fprintf (stderr, "Couldn't open '%s' to import: %s\n",
+	       file, strerror (errno));
+      return -1;
+    }
+
+  rc = fstat (fd, &statbuf);
+  if (rc == -1)
+    {
+      fprintf (stderr, "Could not stat '%s': %s\n",
+	      file, strerror (errno));
+      close (fd);
+      return -1;
+    }
+
+  entries = statbuf.st_size / sizeof (struct utmp);
+  if (entries * (off_t) sizeof (struct utmp) != statbuf.st_size)
+    {
+      fprintf (stderr, "Warning: utmp-format file is not a multiple of "
+		       "sizeof(struct utmp) in length: %zd spare bytes, %s\n",
+	       statbuf.st_size - entries * sizeof (struct utmp), file);
+    }
+
+  data = mmap (NULL, statbuf.st_size, PROT_READ, MAP_SHARED, fd, 0);
+  if (data == MAP_FAILED)
+    {
+      fprintf (stderr, "Could not map file to import: %s\n", strerror (errno));
+      close (fd);
+      return -1;
+    }
+
+  rc = import_utmp_records (db_path, data, entries, &error);
+  if (rc == -1)
+    {
+      fprintf (stderr, "Error importing %s: %sn", file, error);
+      free(error);
+    }
+
+  munmap (data, statbuf.st_size);
+  close (fd);
+  return rc;
+}

--- a/src/import.h
+++ b/src/import.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-2-Clause
+
+  Copyright (c) 2025, Andrew Bower <andrew@bower.uk>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#pragma once
+
+int
+import_wtmp_file (const char *db_path,
+		  const char *file);


### PR DESCRIPTION
Hi, I've added an importer for legacy wtmp log files!

What do you think? I think this would be a popular addition to the tool.

```
$ build/wtmpdb import -f foo.db wtmp
$ last -f foo.db
```
```
abc12    pts/0        2001:db8:123:456 Tue Jul 12 23:12 - 00:12  (01:00)
abc12    pts/0        2001:db8:123:456 Sun Jul 10 20:24 - 23:59  (03:34)
reboot   system boot  5.10.0-16-amd64  Sun Jul 10 20:23 - 22:46 (7+02:22)
abc12    pts/3        2001:db8:123:345 Sun Jul 10 20:14 - 20:23  (00:08)
abc12    pts/1        2001:db8:123:456 Sat Jul  9 19:10 - 15:30  (20:19)
abc12    pts/0        2001:db8:123:456 Sat Jul  9 18:50 - 20:23 (1+01:32)
abc12    pts/0        192.0.2.123      Tue Jul  5 10:11 - 10:40  (00:29)
abc12    pts/0        192.0.2.123      Tue Jul  5 09:26 - 09:42  (00:16)
reboot   system boot  4.19.0-20-amd64  Tue Jul  5 09:24 - 20:23 (5+10:58)
abc12    pts/1        198.51.100.223   Tue Jul  5 09:21 - 09:23  (00:01)
abc12    pts/2        2001:db8:123:456 Tue Jul  5 08:17 - 08:26  (00:08)
abc12    pts/0        2001:db8:123:456 Tue Jul  5 08:07 - 09:23  (01:15)

foo.db begins Fri Oct  2 00:37:29 2020
```

The first commit moves out or qualifies some definitions from the public header file so that it is possible to include `utmp.h` at the same time, either for the importer or for any users of the library.

Closes #14.