### PR TITLE
i386: fix integer format length errors

### DIFF
--- a/lib/varlink.c
+++ b/lib/varlink.c
@@ -29,6 +29,7 @@
 
 #if WITH_WTMPDBD
 
+#include <inttypes.h>
 #include <stdlib.h>
 #include <stdbool.h>
 #include <systemd/sd-varlink.h>
@@ -629,16 +630,16 @@ varlink_read_all (int (*cb_func)(void *unused, int argc, char **argv,
 	}
 
       char *ret[8];
-      if (asprintf (&ret[0], "%li", e.id) < 0)
+      if (asprintf (&ret[0], "%" PRId64, e.id) < 0)
 	return -ENOMEM;
       if (asprintf (&ret[1], "%i", e.type) < 0)
 	return -ENOMEM;
       ret[2] = e.user;
-      if (asprintf (&ret[3], "%lu", e.login) < 0)
+      if (asprintf (&ret[3], "%" PRIu64, e.login) < 0)
 	return -ENOMEM;
       if (e.logout > 0)
 	{
-	  if (asprintf (&ret[4], "%lu", e.logout) < 0)
+	  if (asprintf (&ret[4], "%" PRIu64, e.logout) < 0)
 	    return -ENOMEM;
 	}
       else

--- a/tests/tst-get_id.c
+++ b/tests/tst-get_id.c
@@ -29,6 +29,7 @@
    Try to get the ID for an non-existing tty
 */
 
+#include <inttypes.h>
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,12 +51,12 @@ main(void)
 
   if (id == -2)
     {
-       printf ("wtmpdb_get_id returned expected: %li, '%s'\n",
+       printf ("wtmpdb_get_id returned expected: %" PRId64 ", '%s'\n",
                id, error);
        return 0;
     }
 
-  fprintf (stderr, "wtmpdb_get_id returns '%ld' with error message: %s\n",
+  fprintf (stderr, "wtmpdb_get_id returns '%" PRId64 "' with error message: %s\n",
 	   id, error);
   return 1;
 }

--- a/tests/tst-varlink.c
+++ b/tests/tst-varlink.c
@@ -29,6 +29,7 @@
    Create login entry, search for ID, add logout time, get boottime.
 */
 
+#include <inttypes.h>
 #include <time.h>
 #include <errno.h>
 #include <stdio.h>
@@ -75,7 +76,7 @@ main(void)
           free (error);
         }
       else
-	fprintf (stderr, "wtmpdb_login failed (%li)\n", id);
+	fprintf (stderr, "wtmpdb_login failed (%" PRId64 ")\n", id);
 
       if (id == -ECONNREFUSED || id == -ENOENT ||
 	  id == -EACCES || id == -EPROTONOSUPPORT)
@@ -83,7 +84,7 @@ main(void)
 
       return 1;
     }
-  printf ("wtmpdb_login id: %li\n", id);
+  printf ("wtmpdb_login id: %" PRId64 "\n", id);
 
   /* wtmpdb_get_id should return the same ID as wtmpdb_login */
   int64_t newid;
@@ -98,11 +99,11 @@ main(void)
 	fprintf (stderr, "wtmpdb_get_id failed\n");
       return 1;
     }
-  printf ("wtmpdb_get_id: %li\n", newid);
+  printf ("wtmpdb_get_id: %" PRId64 "\n", newid);
 
   if (newid != id)
     {
-      fprintf (stderr, "IDs don't match: %li != %li\n", id, newid);
+      fprintf (stderr, "IDs don't match: %" PRId64 " != %" PRId64 "\n", id, newid);
       return 1;
     }
 
@@ -157,7 +158,7 @@ main(void)
   else if (entries == 0)
     printf ("Nothing to move for wtmpdb_rotate\n");
   else
-    printf ("wtmpdb_rotate moved %lu entries into %s\n", entries, backup);
+    printf ("wtmpdb_rotate moved %" PRIu64 " entries into %s\n", entries, backup);
 
   return 0;
 }


### PR DESCRIPTION
Fixes a number of build warnings and `SIGSEGV` in the `tst-get_id` test:

```
==================================== 3/6 =====================================
test:         tst-get_id
start time:   15:10:45
duration:     0.01s
result:       killed by signal 11 SIGSEGV
command:      UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 MESON_TEST_ITERATION=1 MALLOC_PERTURB_=163 LD_LIBRARY_PATH=/home/ajb85/git/wtmpdb/build/ MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 /home/ajb85/git/wtmpdb/build/tests/tst-get_id
==============================================================================
```

```
[1/13] Compiling C object tests/tst-get_id.p/tst-get_id.c.o
../tests/tst-get_id.c: In function ‘main’:
../tests/tst-get_id.c:53:52: warning: format ‘%li’ expects argument of type ‘long int’, but argument 2 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
   53 |        printf ("wtmpdb_get_id returned expected: %li, '%s'\n",
      |                                                  ~~^
      |                                                    |
      |                                                    long int
      |                                                  %lli
   54 |                id, error);
      |                ~~
      |                |
      |                int64_t {aka long long int}
../tests/tst-get_id.c:58:46: warning: format ‘%ld’ expects argument of type ‘long int’, but argument 3 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
   58 |   fprintf (stderr, "wtmpdb_get_id returns '%ld' with error message: %s\n",
      |                                            ~~^
      |                                              |
      |                                              long int
      |                                            %lld
   59 |            id, error);
      |            ~~
      |            |
      |            int64_t {aka long long int}
[2/13] Compiling C object tests/tst-varlink.p/tst-varlink.c.o
../tests/tst-varlink.c: In function ‘main’:
../tests/tst-varlink.c:78:50: warning: format ‘%li’ expects argument of type ‘long int’, but argument 3 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
   78 |         fprintf (stderr, "wtmpdb_login failed (%li)\n", id);
      |                                                ~~^      ~~
      |                                                  |      |
      |                                                  |      int64_t {aka long long int}
      |                                                  long int
      |                                                %lli
../tests/tst-varlink.c:86:31: warning: format ‘%li’ expects argument of type ‘long int’, but argument 2 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
   86 |   printf ("wtmpdb_login id: %li\n", id);
      |                             ~~^     ~~
      |                               |     |
      |                               |     int64_t {aka long long int}
      |                               long int
      |                             %lli
../tests/tst-varlink.c:101:29: warning: format ‘%li’ expects argument of type ‘long int’, but argument 2 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
  101 |   printf ("wtmpdb_get_id: %li\n", newid);
      |                           ~~^     ~~~~~
      |                             |     |
      |                             |     int64_t {aka long long int}
      |                             long int
      |                           %lli
../tests/tst-varlink.c:105:44: warning: format ‘%li’ expects argument of type ‘long int’, but argument 3 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
  105 |       fprintf (stderr, "IDs don't match: %li != %li\n", id, newid);
      |                                          ~~^            ~~
      |                                            |            |
      |                                            long int     int64_t {aka long long int}
      |                                          %lli
../tests/tst-varlink.c:105:51: warning: format ‘%li’ expects argument of type ‘long int’, but argument 4 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
  105 |       fprintf (stderr, "IDs don't match: %li != %li\n", id, newid);
      |                                                 ~~^         ~~~~~
      |                                                   |         |
      |                                                   long int  int64_t {aka long long int}
      |                                                 %lli
../tests/tst-varlink.c:160:36: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘uint64_t’ {aka ‘long long unsigned int’} [-Wformat=]
  160 |     printf ("wtmpdb_rotate moved %lu entries into %s\n", entries, backup);
      |                                  ~~^                     ~~~~~~~
      |                                    |                     |
      |                                    long unsigned int     uint64_t {aka long long unsigned int}
      |                                  %llu
[3/13] Compiling C object wtmpdb.p/src_import.c.o
../src/import.c: In function ‘import_wtmp_file’:
../src/import.c:169:24: warning: format ‘%zd’ expects argument of type ‘signed size_t’, but argument 3 has type ‘long long int’ [-Wformat=]
  169 |       fprintf (stderr, "Warning: utmp-format file is not a multiple of "
      |                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  170 |                        "sizeof(struct utmp) in length: %zd spare bytes, %s\n",
  171 |                statbuf.st_size - entries * sizeof (struct utmp), file);
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                |
      |                                long long int
../src/import.c:170:58: note: format string is defined here
  170 |                        "sizeof(struct utmp) in length: %zd spare bytes, %s\n",
      |                                                        ~~^
      |                                                          |
      |                                                          int
      |                                                        %lld
[4/13] Compiling C object libwtmpdb.so.0.71.0.p/lib_varlink.c.o
../lib/varlink.c: In function ‘varlink_read_all’:
../lib/varlink.c:632:33: warning: format ‘%li’ expects argument of type ‘long int’, but argument 3 has type ‘int64_t’ {aka ‘long long int’} [-Wformat=]
  632 |       if (asprintf (&ret[0], "%li", e.id) < 0)
      |                               ~~^   ~~~~
      |                                 |    |
      |                                 |    int64_t {aka long long int}
      |                                 long int
      |                               %lli
../lib/varlink.c:637:33: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint64_t’ {aka ‘long long unsigned int’} [-Wformat=]
  637 |       if (asprintf (&ret[3], "%lu", e.login) < 0)
      |                               ~~^   ~~~~~~~
      |                                 |    |
      |                                 |    uint64_t {aka long long unsigned int}
      |                                 long unsigned int
      |                               %llu
../lib/varlink.c:641:37: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘uint64_t’ {aka ‘long long unsigned int’} [-Wformat=]
  641 |           if (asprintf (&ret[4], "%lu", e.logout) < 0)
      |                                   ~~^   ~~~~~~~~
      |                                     |    |
      |                                     |    uint64_t {aka long long unsigned int}
      |                                     long unsigned int
      |                                   %llu
[9/9] Linking target wtmpdb
```