### PR TITLE
Compat for hurd-amd64 architecture

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -1019,7 +1019,11 @@ main_boot (int argc, char **argv)
   struct timespec ts_now;
   struct timespec ts_boot;
   clock_gettime (CLOCK_REALTIME, &ts_now);
+#ifdef CLOCK_BOOTTIME
   clock_gettime (CLOCK_BOOTTIME, &ts_boot);
+#else
+  ts_boot = ts_now;
+#endif
   uint64_t time = wtmpdb_timespec2usec (diff_timespec(&ts_now, &ts_boot));
 #if HAVE_SYSTEMD
   struct timespec ts_empty = { .tv_sec = 0, .tv_nsec = 0 };

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -3,7 +3,8 @@
 libdl = cc.find_library('dl')
 
 
-tst_dlopen_exe = executable('tst-dlopen', 'tst-dlopen.c', dependencies : libdl)
+tst_dlopen_exe = executable('tst-dlopen', 'tst-dlopen.c', dependencies : libdl,
+                        include_directories : inc)
 test('tst-dlopen', tst_dlopen_exe, args : ['pam_wtmpdb.so'])
 
 tst_y2038_64bit_time_t = executable('tst-y2038-64bit-time_t', 'tst-y2038-64bit-time_t.c')

--- a/tests/tst-dlopen.c
+++ b/tests/tst-dlopen.c
@@ -13,23 +13,25 @@
 
 #include <dlfcn.h>
 #include <stdio.h>
-#include <limits.h>
+#include <stdlib.h>
 #include <sys/stat.h>
+#include "basics.h"
 
 /* Simple program to see if dlopen() would succeed. */
 int main(int argc, char **argv)
 {
   int i;
+  int rc;
   struct stat st;
-  char buf[PATH_MAX];
+  _cleanup_(freep) char *buf = NULL;
 
   for (i = 1; i < argc; i++) {
     if (dlopen(argv[i], RTLD_NOW)) {
       fprintf(stdout, "dlopen() of \"%s\" succeeded.\n",
               argv[i]);
     } else {
-      snprintf(buf, sizeof(buf), "./%s", argv[i]);
-      if ((stat(buf, &st) == 0) && dlopen(buf, RTLD_NOW)) {
+      rc = asprintf(&buf, "./%s", argv[i]);
+      if (rc >= 0 && (stat(buf, &st) == 0) && dlopen(buf, RTLD_NOW)) {
         fprintf(stdout, "dlopen() of \"./%s\" "
                 "succeeded.\n", argv[i]);
       } else {


### PR DESCRIPTION
Hi, thanks for the 0.72.0 release - looks solid!

I have a couple of patches here for consideration that enable wtmpdb to build, run and pass tests on the hurd-amd64 architecture.

(The hurd-i386 architecture cannot be supported because it does not have t64 capability in the kernel).

1. Hurd does not have `PATH_MAX` defined - it's a design principle for that architecture to avoid fixed limits.
2. Hurd does not have `CLOCK_BOOTTIME` yet - but its use here looks to be non-essential.