### PR TITLE
use documented -t short option for last --until

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -734,7 +734,7 @@ main_last (int argc, char **argv)
     {"service", no_argument, NULL, 'S'},
     {"since", required_argument, NULL, 's'},
     {"system", no_argument, NULL, 'x'},
-    {"until", required_argument, NULL, 'u'},
+    {"until", required_argument, NULL, 't'},
     {"time-format", required_argument, NULL, TIMEFMT_VALUE},
     {"json", no_argument, NULL, 'j'},
     {NULL, 0, NULL, '\0'}
@@ -804,7 +804,7 @@ main_last (int argc, char **argv)
 	case 'S':
 	  noservice = 0;
 	  break;
-	case 'u':
+	case 't':
 	  if (parse_time (optarg, &until) < 0)
 	    {
 	      fprintf (stderr, "Invalid time value '%s'\n", optarg);


### PR DESCRIPTION
Hi, a Debian user has [reported](https://bugs.debian.org/1102102) that the documented short option (`-t`) for (`last --until`) does not work. It is listed in the getopt string but a different character is used for the long option definition and matched in the switch statement.

This patch fixes this problem and makes `last -t` work as documented and expected.

Because `u` was not listed in the getopt string `-u` would not have been effective for anyone so this change should not cause any regression.

Thanks!