### PR TITLE
ensure local DST state used with absolute time specs

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -134,7 +134,7 @@ isipaddr (const char *string, int *addr_type,
 static int
 parse_time (const char *str, time_t *arg)
 {
-  struct tm res = { 0 };
+  struct tm res = { .tm_isdst = -1 };
 
   if (strcmp (str, "today") == 0)
     {


### PR DESCRIPTION
Sorry, my fix in #22 was inadequate: the `tm_isdst` value needed to be initialised to `-1`, as indeed you did for the relative time options, not to `0`. Indeterminate behaviour was fixed but it was only correct when DST did not prevail. With this PR the behaviour seems to be correct.

(I don't know if the assignments in lines 143 and 150 can be dropped? They should be safe to stay, though.)

(Also, are we supposed to have called `tzset` before `mktime()`? I am not sure.)