### PR TITLE
expand accepted time format options

### DIFF
--- a/man/wtmpdb.8.xml
+++ b/man/wtmpdb.8.xml
@@ -219,10 +219,17 @@
 	  </variablelist>
 	  <para>
 	    <replaceable>TIME</replaceable> must be in the format
+	    <option>"YYYYMMDDHHMMSS"</option>,
 	    <option>"YYYY-MM-DD HH:MM:SS"</option>,
-	    <option>"YYYY-MM-DD"</option>, <option>"today"</option> or
-	    <option>"yesterday"</option> (time will be set to 00:00:00
-	    if not specified).
+	    <option>"YYYY-MM-DD HH:MM"</option>,
+	    <option>"YYYY-MM-DD"</option>,
+	    <option>"HH:MM:SS"</option>,
+	    <option>"HH:MM"</option>,
+	    <option>"now"</option>,
+	    <option>"today"</option>,
+	    <option>"yesterday"</option> or
+	    <option>"tomorrow"</option> (time will be set to 00:00:00
+	    if not specified; the date to today's).
 	  </para>
 	</listitem>
       </varlistentry>


### PR DESCRIPTION
Hi,

I've tried to add support for `now` as a time specification (closes #32) and expand to accept all the time specifications accepted by the old last except for the +/- time period variants.

This PR, if accepted, would supersede #31.

It would be quite easy to add a couple more format string constants to satisfy #34 but I just started with the ones matching old 'last'.