### PR TITLE
import: match login by tty if non-zero pid does not match

### DIFF
--- a/src/import.c
+++ b/src/import.c
@@ -114,7 +114,7 @@ import_utmp_records (const char *db_path,
 	    {
 	      if (v->ut_type == UTMP_USER_PROCESS &&
 		  ((u->ut_pid != 0 && v->ut_pid == u->ut_pid) ||
-		   (u->ut_pid == 0 && strncmp (v->ut_line, u->ut_line, UT_LINESIZE) == 0)))
+		   (strncmp (v->ut_line, u->ut_line, UT_LINESIZE) == 0)))
 		{
 		  id = id_map[v - utmp_data];
 		  if (id > 0)


### PR DESCRIPTION
Thanks for releasing 0.73.0! Sorry for the bad timing with this fix but I just found the issue in system upgrade testing.

The existing code matches a utmp logout entry to a login entry by the preferred pid method if possible and then by tty if the pid is zero (over-cautiously). This does not correspond to some servers that record the logout with a different value in the pid field, resulting in the logout times being recorded as 'crash'.

I.e. the old code covered this scenario:

```
[7] [3644869] [ts/0] [xxxxx   ] [pts/0       ] [xxx.xxx.xxx.xx      ] [xxx.xxx.xxx.xx ] [2025-04-06T20:50:13,349247+00:00]
[8] [3644869] [    ] [        ] [pts/0       ] [                    ] [0.0.0.0        ] [2025-04-06T20:57:16,283472+00:00]
```

But not this:

```
[7] [00343] [ts/0] [root    ] [pts/0       ] [xxxx:xxx:xxx:xxx::x ] [xxxx:xxx:xxx:xx] [Tue Sep 21 17:02:51 2021 BST]
[8] [00328] [    ] [        ] [pts/0       ] [                    ] [0.0.0.0        ] [Tue Sep 21 17:17:00 2021 BST]
```

This patch fixes it so imports works from both types of system.

### Before
```
root     pts/0        2001:xxx:xxx:xxx Tue Sep 21 11:56 - crash 
reboot   system boot  5.10.0-8-amd64   Tue Sep 21 11:55 - 11:56  (00:00)
root     pts/0        2001:xxx:xxx:xxx Tue Sep 21 11:49 - crash 
reboot   system boot  5.10.0-8-amd64   Tue Sep 21 11:49 - 11:50  (00:01)
```

### After
```
root     pts/0        2001:xxx:xxx:xxx Tue Sep 21 11:56 - 11:56  (00:00)
reboot   system boot  5.10.0-8-amd64   Tue Sep 21 11:55 - 11:56  (00:00)
root     pts/0        2001:xxx:xxx:xxx Tue Sep 21 11:49 - 11:50  (00:01)
reboot   system boot  5.10.0-8-amd64   Tue Sep 21 11:49 - 11:50  (00:01)
```