### PR TITLE
avoid noise if systemd not running

### DIFF
--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -1005,8 +1005,9 @@ soft_reboots_count (void)
 				   &error, 'u', &soft_reboots_count);
   if (r < 0)
     {
-      /* systemd is too old, don't print error */
-      if (!sd_bus_error_has_name (&error, SD_BUS_ERROR_UNKNOWN_PROPERTY))
+      /* no systemd or systemd is too old: don't print error */
+      if (!sd_bus_error_has_name (&error, SD_BUS_ERROR_SERVICE_UNKNOWN) &&
+          !sd_bus_error_has_name (&error, SD_BUS_ERROR_UNKNOWN_PROPERTY))
 	{
 	  /* error occured, log it and return to fallback code */
 	  if (error.message)

--- a/src/wtmpdb.c
+++ b/src/wtmpdb.c
@@ -995,7 +995,6 @@ soft_reboots_count (void)
 
   if (sd_bus_open_system (&bus) < 0)
     {
-      fprintf (stderr, "Error: cannot open dbus");
       return -1;
     }
 


### PR DESCRIPTION
Hi,

If wtmpdb is run without systemd then a message is printed every boot about failing to count soft reboots (also similarly in a minimal system without even dbus).

It seems to me that if this happens then soft reboot counts are irrelevant because they are a systemd concept to begin with so it is sufficient to fail silently.

If the system is broken in some more fundamental way then I think that will not need wtmpdb to be the means by which the user is informed - so I suspect the value of these messages might only be during development.

Debian has carried this patch for 10 months without any issue - would you be prepared to take it or something equivalent/better upstream?

Thanks!